### PR TITLE
Fix E2E test crashing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,5 @@ jobs:
         env:
           CI: true
           CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context
-          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process'
+          HOME: '/tmp'
+          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote --user-data-dir=/tmp/chrome-profile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
         run: docker compose run --rm -w /app/data --entrypoint "npm" svg-to-video run test:e2e
         env:
           CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context
-          PUPPETEER_ARGS: '--user-data-dir=/app/data/.chromium_user_data' # Direct Chrome to a writable user data directory
-          HOME: '/app/data' # Set HOME to a writable directory for Chrome
+          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --user-data-dir=/tmp/.chromium_user_data --single-process --no-zygote' # Direct Chrome to a writable user data directory in /tmp
+          HOME: '/tmp' # Set HOME to /tmp inside the container for Chrome

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,14 @@ jobs:
       # Run E2E tests inside the Docker container using docker compose
       - name: Run E2E tests in Docker
         # Override the service's entrypoint to run npm, then execute the test script
-        run: docker compose run --rm --user root -w /app/data --entrypoint "npm" svg-to-video run test:e2e
-        env:
-          CI: true
-          CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context
-          HOME: '/tmp'
-          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote --user-data-dir=/tmp/chrome-profile'
+        run: >
+          docker compose run
+          --rm
+          --user root
+          -e HOME=/tmp
+          -e PUPPETEER_ARGS="--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote --user-data-dir=/tmp/chrome-profile"
+          -e CI=true 
+          -e CI_DOCKER_TEST=true 
+          -w /app/data
+          --entrypoint "npm"
+          svg-to-video run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 1. Mise en place du cache Docker pour accélérer les builds futurs
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build and load Docker image
+        uses: docker/build-push-action@v5
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          context: .
+          load: true
+          tags: svg-to-video:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # 2. Setup Node pour les checks rapides (Lint/Format)
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20' # Or latest LTS
           cache: 'npm'
@@ -37,22 +36,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Run fast checks directly on the runner
       - name: Run fast checks (lint, format, type-check)
         run: npm run check:fast
 
       # --- E2E Tests (run in Docker) ---
-      # Set up User IDs for docker compose, as before
+
       - name: Set up User IDs for Docker
         run: |
           echo "UID=$(id -u)" >> $GITHUB_ENV
           echo "GID=$(id -g)" >> $GITHUB_ENV
 
-      # Build the Docker image using docker compose
-      - name: Build Docker Image for E2E
-        run: docker compose build svg-to-video # Build only the relevant service
-
-      # Run E2E tests inside the Docker container using docker compose
       - name: Run E2E tests in Docker
         # Override the service's entrypoint to run npm, then execute the test script
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           CI: true
           CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context
-          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote'
+          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,7 @@ jobs:
         run: >
           docker compose run
           --rm
-          --user root
           -e HOME=/tmp
-          -e PUPPETEER_ARGS="--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote --user-data-dir=/tmp/chrome-profile"
           -e CI=true 
           -e CI_DOCKER_TEST=true 
           -w /app/data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
+      # 1. Mise en place du cache Docker pour accélérer les builds futurs
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # 2. Setup Node pour les checks rapides (Lint/Format)
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20' # Or latest LTS
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # Run fast checks directly on the runner
       - name: Run fast checks (lint, format, type-check)
@@ -41,6 +56,6 @@ jobs:
         # Override the service's entrypoint to run npm, then execute the test script
         run: docker compose run --rm -w /app/data --entrypoint "npm" svg-to-video run test:e2e
         env:
+          CI: true
           CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context
-          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --user-data-dir=/tmp/.chromium_user_data --single-process --no-zygote' # Direct Chrome to a writable user data directory in /tmp
-          HOME: '/tmp' # Set HOME to /tmp inside the container for Chrome
+          PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --single-process --no-zygote'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  tests:
+    name: 'Testing (Lint, Format, Type-Check, E2E)'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,8 @@ jobs:
         run: >
           docker compose run
           --rm
-          -e HOME=/tmp
           -e CI=true 
-          -e CI_DOCKER_TEST=true 
+          -e DOCKER_TEST=true 
           -w /app/data
           --entrypoint "npm"
           svg-to-video run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # Run E2E tests inside the Docker container using docker compose
       - name: Run E2E tests in Docker
         # Override the service's entrypoint to run npm, then execute the test script
-        run: docker compose run --rm -w /app/data --entrypoint "npm" svg-to-video run test:e2e
+        run: docker compose run --rm --user root -w /app/data --entrypoint "npm" svg-to-video run test:e2e
         env:
           CI: true
           CI_DOCKER_TEST: 'true' # Set environment variable for the test to detect Docker context

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-slim
 # 1. Setup Environment
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable \
-    NODE_ENV=production
+    NODE_ENV=production \
+    HOME=/tmp/chrome-home
 
 # 2. Heavy Layer: Chrome & Core Dependencies (Rarely changes)
 RUN apt-get update && apt-get install -y \
@@ -36,17 +37,17 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# 4. App Dependencies (Only rebuilds if package.json changes)
+# 4. Create a directory for Chrome's user data and set permissions for allowing non-root users to write to it.
+# 5. Create a directory for output data and set permissions for allowing non-root users to write to it.
+RUN mkdir -p /tmp/chrome-home && chmod 777 /tmp/chrome-home \
+    && mkdir -p /app/data && chmod 777 /app/data
+
+# 6. App Dependencies (Only rebuilds if package.json changes)
 COPY package*.json ./
 RUN npm install --omit=dev --ignore-scripts
 
-# 5. Application Code (Changes most often)
+# 7. Application Code (Changes most often)
 COPY . .
-RUN mkdir -p /app/data \
-    && chown -R node:node /app \
-    && mkdir -p /home/node/Downloads \
-    && chown -R node:node /home/node/Downloads \
-    && usermod -a -G audio,video node
 
 USER node
 ENTRYPOINT ["node", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ RUN npm install --omit=dev --ignore-scripts
 
 # 5. Application Code (Changes most often)
 COPY . .
-RUN mkdir -p /app/data && chown -R node:node /app
+RUN mkdir -p /app/data \
+    && chown -R node:node /app \
+    && mkdir -p /home/node/Downloads \
+    && chown -R node:node /home/node/Downloads \
+    && usermod -a -G audio,video node
 
 USER node
 ENTRYPOINT ["node", "src/index.js"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ node src/index.js <svgPath> <duration> <fps> <outDir> [options]
 | `-f, --force`          | Overwrite the output video if it already exists.                                   |
 | `--keep-frames`        | Prevents the automatic deletion of temporary `.png` frames after video creation.   |
 
+### Environment Variables
+
+| Variable         | Scope     | Description                                                                                                                                       |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PUPPETEER_ARGS` | Runtime   | Additional arguments passed directly to the Puppeteer `launch` method. Useful for custom browser flags (e.g., `--proxy-server`, `--disable-gpu`). |
+| `DOCKER_TEST`    | E2E Tests | Set to `true` when running end-to-end tests inside a Docker container. Adjusts file paths to match the `/app/data` volume mount.                  |
+
 ### 🛠 Troubleshooting (Fedora / SELinux)
 
 If you encounter `Permission Denied` errors on Fedora, ensure the `:Z` flag is present in your `docker-compose.yml` volumes to allow SELinux relabeling.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     # This is a security feature to prevent the container from gaining root
     security_opt:
       - no-new-privileges:true
+    shm_size: '2gb'

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,6 @@ async function createFrames(
   svg = svg.replace(/--play-state:\s*running\s*;/g, '--play-state: paused;');
 
   const browser = await puppeteer.launch({
-    dumpio: true,
     headless: true,
     args: ['--no-sandbox', ...puppeteerArgs],
   });

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,10 @@ async function run(svgPath, duration, fps, outDir, options) {
     process.exit(1);
   }
 
+  const puppeteerArgs = (process.env.PUPPETEER_ARGS || '')
+    .split(' ')
+    .filter((arg) => arg.trim().length > 0);
+
   const svg = fs.readFileSync(svgPath, 'utf-8');
 
   const totalFrames = Math.ceil(fps * duration);
@@ -77,12 +81,15 @@ async function run(svgPath, duration, fps, outDir, options) {
   console.log(
     `  Settings:   ${duration}s @ ${fps}fps (Hold: ${options.hold}s)`
   );
+  if (puppeteerArgs.length > 0) {
+    console.log(`  Puppeteer:  ${puppeteerArgs.join(' ')}`);
+  }
   console.log(`  Frames:     ${totalFrames} total`);
   console.log('---');
 
   fs.mkdirSync(outDir, { recursive: true });
 
-  await createFrames(svg, fps, totalFrames, padWidth, outDir);
+  await createFrames(svg, fps, totalFrames, padWidth, outDir, puppeteerArgs);
   convertToMP4(outputFileName, fps, padWidth, options.hold, outDir);
 
   if (!options.keepFrames) {
@@ -99,29 +106,26 @@ async function run(svgPath, duration, fps, outDir, options) {
  * @param {number} totalFrames
  * @param {number} padWidth
  * @param {string} outDir
+ * @param {string[]} puppeteerArgs
  */
-async function createFrames(svg, fps, totalFrames, padWidth, outDir) {
+async function createFrames(
+  svg,
+  fps,
+  totalFrames,
+  padWidth,
+  outDir,
+  puppeteerArgs
+) {
   // advance every animation to the desired timestamp. we use the Web
   // Animations API (`document.getAnimations()`) and set `currentTime` on
   // each animation, which works for any SVG regardless of how its
   // animations are defined.
   svg = svg.replace(/--play-state:\s*running\s*;/g, '--play-state: paused;');
 
-  console.log('--- DEBUG INFO ---');
-  console.log('Current UID:', process.getuid?.());
-  console.log('HOME env:', process.env.HOME);
-  console.log('PUPPETEER_ARGS:', process.env.PUPPETEER_ARGS);
-  console.log('------------------');
-
   const browser = await puppeteer.launch({
     dumpio: true,
     headless: true,
-    args: [
-      '--no-sandbox',
-      ...(process.env.PUPPETEER_ARGS
-        ? process.env.PUPPETEER_ARGS.split(' ')
-        : []),
-    ],
+    args: ['--no-sandbox', ...puppeteerArgs],
   });
 
   const page = await browser.newPage();

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,12 @@ async function createFrames(svg, fps, totalFrames, padWidth, outDir) {
 
   const browser = await puppeteer.launch({
     headless: true,
-    args: ['--no-sandbox'],
+    args: [
+      '--no-sandbox',
+      ...(process.env.PUPPETEER_ARGS
+        ? process.env.PUPPETEER_ARGS.split(' ')
+        : []),
+    ],
   });
 
   const page = await browser.newPage();

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,14 @@ async function createFrames(svg, fps, totalFrames, padWidth, outDir) {
   // animations are defined.
   svg = svg.replace(/--play-state:\s*running\s*;/g, '--play-state: paused;');
 
+  console.log('--- DEBUG INFO ---');
+  console.log('Current UID:', process.getuid?.());
+  console.log('HOME env:', process.env.HOME);
+  console.log('PUPPETEER_ARGS:', process.env.PUPPETEER_ARGS);
+  console.log('------------------');
+
   const browser = await puppeteer.launch({
+    dumpio: true,
     headless: true,
     args: [
       '--no-sandbox',

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -9,9 +9,6 @@ import {
   resolveEnvironmentPath,
 } from './utils.mjs';
 
-const logs = [];
-const logger = (msg) => logs.push(`[${new Date().toISOString()}] ${msg}`);
-
 describe('End-to-End Rendering', () => {
   const TEST_SVG_NAME = 'font-test';
   const inputFileRelative = path.join(
@@ -46,49 +43,19 @@ describe('End-to-End Rendering', () => {
   });
 
   test('should render font-test.svg into a valid mp4 file', () => {
-    logger('Starting test...');
-    logger(`UID: ${process.getuid()}`);
-    logger(`HOME: ${process.env.HOME}`);
-
-    let result;
-    try {
-      // 2. Execute the CLI tool
-      result = spawnSync(
-        'node',
-        [
-          'src/index.js',
-          inputFile,
-          '1', // duration
-          '30', // fps
-          outputDir,
-          '--force',
-        ],
-        { encoding: 'utf-8' }
-      );
-      logger(result.stdout);
-      if (result.stderr) {
-        logger(`STDERR: ${result.stderr}`);
-      }
-    } catch (err) {
-      logger(`FATAL ERROR: ${err.message}`);
-      if (err.stack) logger(err.stack);
-
-      // ICI : On force l'affichage de TOUT ce qu'on a capturé sur stderr
-      // fs.writeSync est synchrone et ne peut pas être intercepté par le test runner
-      fs.writeSync(
-        2,
-        `\n=== CAPTURED LOGS ON FAILURE ===\n${logs.join('\n')}\n================================\n`
-      );
-      logs.length = 0; // Clear logs after dumping
-
-      // On re-balance l'erreur pour que le test soit marqué comme "failed"
-      throw err;
-    }
-    fs.writeSync(
-      2,
-      `\n=== CAPTURED LOGS ON SUCCESS ===\n${logs.join('\n')}\n================================\n`
+    const result = spawnSync(
+      'node',
+      [
+        'src/index.js',
+        inputFile,
+        '1', // duration
+        '30', // fps
+        outputDir,
+        '--force',
+      ],
+      { encoding: 'utf-8' }
     );
-    // 3. Assertions
+
     assert.strictEqual(
       result.status,
       0,

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -14,7 +14,7 @@ const logger = (msg) => logs.push(`[${new Date().toISOString()}] ${msg}`);
 
 describe('End-to-End Rendering', () => {
   const TEST_SVG_NAME = 'font-test';
-  const testSvgPathRelative = path.join(
+  const inputFileRelative = path.join(
     FIXTURE_DIR_RELATIVE,
     `${TEST_SVG_NAME}.svg`
   );
@@ -24,23 +24,24 @@ describe('End-to-End Rendering', () => {
     `${TEST_SVG_NAME}.mp4`
   );
 
-  const cliSvgPathArg = resolveEnvironmentPath(testSvgPathRelative);
-  const cliOutputDirArg = resolveEnvironmentPath(OUTPUT_DIR_RELATIVE);
+  const inputFile = resolveEnvironmentPath(inputFileRelative);
+  const outputDir = resolveEnvironmentPath(OUTPUT_DIR_RELATIVE);
+  const outputFile = resolveEnvironmentPath(outputFileRelative);
 
   before(() => {
     // Ensure output directory exists before tests run
-    if (!fs.existsSync(OUTPUT_DIR_RELATIVE)) {
-      fs.mkdirSync(OUTPUT_DIR_RELATIVE, { recursive: true });
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
     }
   });
 
   after(() => {
     // Cleanup output directory and file after all tests
-    if (fs.existsSync(outputFileRelative)) {
-      fs.unlinkSync(outputFileRelative);
+    if (fs.existsSync(outputFile)) {
+      fs.unlinkSync(outputFile);
     }
-    if (fs.existsSync(OUTPUT_DIR_RELATIVE)) {
-      fs.rmSync(OUTPUT_DIR_RELATIVE, { recursive: true, force: true });
+    if (fs.existsSync(outputDir)) {
+      fs.rmSync(outputDir, { recursive: true, force: true });
     }
   });
 
@@ -56,10 +57,10 @@ describe('End-to-End Rendering', () => {
         'node',
         [
           'src/index.js',
-          cliSvgPathArg,
+          inputFile,
           '1', // duration
           '30', // fps
-          cliOutputDirArg,
+          outputDir,
           '--force',
         ],
         { encoding: 'utf-8' }
@@ -93,12 +94,9 @@ describe('End-to-End Rendering', () => {
       0,
       `Process failed with stderr: ${result.stderr}`
     );
-    assert.ok(
-      fs.existsSync(outputFileRelative),
-      'The output MP4 file was not created'
-    );
+    assert.ok(fs.existsSync(outputFile), 'The output MP4 file was not created');
 
-    const stats = fs.statSync(outputFileRelative);
+    const stats = fs.statSync(outputFile);
     assert.ok(
       stats.size > 1000,
       'The generated video file is suspiciously small (possibly empty)'

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -9,6 +9,9 @@ import {
   resolveEnvironmentPath,
 } from './utils.mjs';
 
+const logs = [];
+const logger = (msg) => logs.push(`[${new Date().toISOString()}] ${msg}`);
+
 describe('End-to-End Rendering', () => {
   const TEST_SVG_NAME = 'font-test';
   const testSvgPathRelative = path.join(
@@ -42,20 +45,48 @@ describe('End-to-End Rendering', () => {
   });
 
   test('should render font-test.svg into a valid mp4 file', () => {
-    // 2. Execute the CLI tool
-    const result = spawnSync(
-      'node',
-      [
-        'src/index.js',
-        cliSvgPathArg,
-        '1', // duration
-        '30', // fps
-        cliOutputDirArg,
-        '--force',
-      ],
-      { encoding: 'utf-8' }
-    );
+    logger('Starting test...');
+    logger(`UID: ${process.getuid()}`);
+    logger(`HOME: ${process.env.HOME}`);
 
+    let result;
+    try {
+      // 2. Execute the CLI tool
+      result = spawnSync(
+        'node',
+        [
+          'src/index.js',
+          cliSvgPathArg,
+          '1', // duration
+          '30', // fps
+          cliOutputDirArg,
+          '--force',
+        ],
+        { encoding: 'utf-8' }
+      );
+      logger(result.stdout);
+      if (result.stderr) {
+        logger(`STDERR: ${result.stderr}`);
+      }
+    } catch (err) {
+      logger(`FATAL ERROR: ${err.message}`);
+      if (err.stack) logger(err.stack);
+
+      // ICI : On force l'affichage de TOUT ce qu'on a capturé sur stderr
+      // fs.writeSync est synchrone et ne peut pas être intercepté par le test runner
+      fs.writeSync(
+        2,
+        `\n=== CAPTURED LOGS ON FAILURE ===\n${logs.join('\n')}\n================================\n`
+      );
+      logs.length = 0; // Clear logs after dumping
+
+      // On re-balance l'erreur pour que le test soit marqué comme "failed"
+      throw err;
+    }
+    fs.writeSync(
+      2,
+      `\n=== CAPTURED LOGS ON FAILURE ===\n${logs.join('\n')}\n================================\n`
+    );
     // 3. Assertions
     assert.strictEqual(
       result.status,

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -85,7 +85,7 @@ describe('End-to-End Rendering', () => {
     }
     fs.writeSync(
       2,
-      `\n=== CAPTURED LOGS ON FAILURE ===\n${logs.join('\n')}\n================================\n`
+      `\n=== CAPTURED LOGS ON SUCCESS ===\n${logs.join('\n')}\n================================\n`
     );
     // 3. Assertions
     assert.strictEqual(

--- a/tests/utils.mjs
+++ b/tests/utils.mjs
@@ -5,7 +5,7 @@ export const FIXTURE_DIR_RELATIVE = './tests/fixtures';
 export const OUTPUT_DIR_RELATIVE = './out-dir-test';
 
 // Detect Docker environment by checking for a specific environment variable
-export const isDockerEnv = process.env.CI_DOCKER_TEST === 'true';
+export const isDockerEnv = process.env.DOCKER_TEST === 'true';
 
 /**
  * Returns an environment-aware path for CLI arguments.


### PR DESCRIPTION
Fix E2E tests failing on CI

```
      location: '/app/data/tests/e2e.test.mjs:44:3'
      failureType: 'testCodeFailure'
      error: |-
        Process failed with stderr: /app/data/node_modules/@puppeteer/browsers/lib/cjs/launch.js:350
                        reject(new Error([
                               ^
        
        Error: Failed to launch the browser process:  Code: null
        
        stderr:
        mkdir: cannot create directory '//.local': Permission denied
        touch: cannot touch '//.local/share/applications/mimeapps.list': No such file or directory
        chrome_crashpad_handler: --database is required
        Try 'chrome_crashpad_handler --help' for more information.
```