### PR TITLE
Potential fix for code scanning alert no. 4: Client-side cross-site scripting

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -211,7 +211,7 @@ The Web Studio uses [Umami Analytics](https://umami.is/) for anonymous usage tra
 ## 🐳 Docker & Hardening
 
 - **Security**: The application runs as the non-root `node` user.
-
+- **Renderer Isolation**: The `SvgRenderer` iframe runs in a unique, isolated origin (`null`) by using the `sandbox="allow-scripts"` attribute. This prevents script-based sandbox escapes. Communication is strictly enforced via `postMessage` with origin validation on both the parent and renderer sides.
 - **Exclusions**: Development-only files like `specs/`, `AGENTS.md`, and `DEVELOPER.md` are excluded from the image via `.dockerignore`.
 
 ## 🎥 Extending Output Formats and Transparency Support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/GehDoc/svg-to-video/actions/workflows/ci.yml/badge.svg)](https://github.com/GehDoc/svg-to-video/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.9.3-blue.svg)](https://github.com/GehDoc/svg-to-video/releases)
+[![Version](https://img.shields.io/badge/version-0.9.4-blue.svg)](https://github.com/GehDoc/svg-to-video/releases)
 
 ![Social Preview](./docs/assets/social-preview.svg)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svg-to-video",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svg-to-video",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "workspaces": [
         "web"
@@ -3749,6 +3749,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/umami": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@types/umami/-/umami-2.10.1.tgz",
@@ -5947,6 +5954,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -13164,9 +13180,10 @@
     },
     "web": {
       "name": "@svg-to-video/web",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "coi-serviceworker": "^0.1.7",
+        "dompurify": "^3.4.3",
         "mediabunny": "^1.39.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svg-to-video",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svg-to-video",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "workspaces": [
         "web"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,13 +3749,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/umami": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@types/umami/-/umami-2.10.1.tgz",
@@ -5954,15 +5947,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "1"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -13183,7 +13167,6 @@
       "version": "0.9.3",
       "dependencies": {
         "coi-serviceworker": "^0.1.7",
-        "dompurify": "^3.4.3",
         "mediabunny": "^1.39.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-to-video",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "description": "Professional animated SVG to MP4/WebM/MKV/MOV converter featuring frame-accurate rendering, CLI automation, and a serverless Web Studio.",
   "author": "GehDoc",

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,8 @@
     "mediabunny": "^1.39.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-icons": "^5.6.0"
+    "react-icons": "^5.6.0",
+    "dompurify": "^3.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svg-to-video/web",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "High-fidelity, browser-based SVG to video Studio (MP4, WebM, MKV, MOV) with transparent background support and frame-accurate rendering.",
   "author": "GehDoc",
   "private": true,

--- a/web/package.json
+++ b/web/package.json
@@ -25,8 +25,7 @@
     "mediabunny": "^1.39.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-icons": "^5.6.0",
-    "dompurify": "^3.4.3"
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/src/components/SvgRenderer/index.tsx
+++ b/web/src/components/SvgRenderer/index.tsx
@@ -247,7 +247,7 @@ const SvgRenderer = memo(
             <iframe
               ref={iframeRef}
               title="svg-renderer"
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts"
               style={{
                 width: dimensions.width,
                 height: dimensions.height,

--- a/web/src/components/SvgRenderer/renderer.js
+++ b/web/src/components/SvgRenderer/renderer.js
@@ -1,5 +1,3 @@
-import DOMPurify from 'dompurify';
-
 /**
  * This is the isolated renderer script that will run inside the iframe.
  * It is injected by SvgRenderer via Blob.
@@ -80,10 +78,7 @@ export function getRendererScript(seekAnimations, parentOrigin) {
 
       isReady = false;
       const { svgContent, width, height, timeMs } = payload;
-      const sanitizedSvgContent = DOMPurify.sanitize(svgContent, {
-        USE_PROFILES: { svg: true, svgFilters: true },
-      });
-      svgContainer.innerHTML = sanitizedSvgContent;
+      svgContainer.innerHTML = svgContent;
       svgContainer.style.width = width + 'px';
       svgContainer.style.height = height + 'px';
       svgContainer.style.backgroundColor = 'transparent';

--- a/web/src/components/SvgRenderer/renderer.js
+++ b/web/src/components/SvgRenderer/renderer.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 /**
  * This is the isolated renderer script that will run inside the iframe.
  * It is injected by SvgRenderer via Blob.
@@ -59,12 +61,29 @@ export function getRendererScript(seekAnimations, parentOrigin) {
   let isReady = false;
 
   window.addEventListener('message', async (event) => {
-    const { type, payload } = event.data;
+    if (event.origin !== parentOrigin || event.source !== window.parent) {
+      return;
+    }
+
+    const { type, payload } = event.data || {};
 
     if (type === 'LOAD_SVG') {
+      if (
+        !payload ||
+        typeof payload.svgContent !== 'string' ||
+        typeof payload.width !== 'number' ||
+        typeof payload.height !== 'number' ||
+        typeof payload.timeMs !== 'number'
+      ) {
+        return;
+      }
+
       isReady = false;
       const { svgContent, width, height, timeMs } = payload;
-      svgContainer.innerHTML = svgContent;
+      const sanitizedSvgContent = DOMPurify.sanitize(svgContent, {
+        USE_PROFILES: { svg: true, svgFilters: true },
+      });
+      svgContainer.innerHTML = sanitizedSvgContent;
       svgContainer.style.width = width + 'px';
       svgContainer.style.height = height + 'px';
       svgContainer.style.backgroundColor = 'transparent';


### PR DESCRIPTION
Potential fix for [https://github.com/GehDoc/svg-to-video/security/code-scanning/4](https://github.com/GehDoc/svg-to-video/security/code-scanning/4)

To fix this without changing intended behavior, apply defense-in-depth at the message handler:

1. **Validate message origin** before reading `event.data`:
   - Require `event.origin === parentOrigin`.
   - Optionally require `event.source === window.parent`.
   - Ignore invalid events early.

~~2. **Sanitize `svgContent`** before assigning to `innerHTML`:~~ **Canceled, too harmful for SVG filters**
- ~~   Use a robust sanitizer (best: `DOMPurify`) configured for SVG.~~
- ~~   Keep only safe tags/attributes/protocols used by SVG rendering.~~



3. **Type-check payload fields** (`svgContent` as string, numeric dimensions/time) to avoid malformed input paths.

In `web/src/components/SvgRenderer/renderer.js`, update the `message` listener region around lines 61–67 to (a) guard sender, (b) validate structure, and (c) sanitize prior to `innerHTML`. Add a `DOMPurify` import at the top of the file.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


Addition : **🛡️ Security Strategy: Origin Isolation**
  After evaluating the risk, we have removed allow-same-origin from the sandbox attribute. The iframe now runs in a unique, isolated origin (null). This effectively prevents any potential script-based sandbox escape, as
  the iframe cannot access the parent's document or sensitive browser state, even if the renderer is compromised.
