### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/GehDoc/svg-to-video/security/code-scanning/3](https://github.com/GehDoc/svg-to-video/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml` so all jobs inherit minimum required token scopes unless overridden.  
For this workflow, the best minimal fix is:

- `contents: read` (needed for `actions/checkout` and repository reads)

This preserves behavior while enforcing least privilege across `tests`, `build-web`, and `web-tests`.

Edit region: near the top of `.github/workflows/ci.yml`, directly after the `on:` triggers and before `env:` (or anywhere valid at workflow root).  
No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
