### PR TITLE
docs: update CLI instructions for TS migration & feat: add home reset navigation to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ensure [Node.js](https://nodejs.org/) and [FFmpeg](https://ffmpeg.org/) are inst
 ```bash
 # Node.js
 npm install
-node src/index.js example.svg 5 60 output.mp4
+npx tsx src/index.ts example.svg 5 60 output.mp4
 
 # Docker
 docker compose build

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -3,7 +3,7 @@
 The tool is built to run in a headless environment, making it perfect for CI/CD pipelines or server-side automation.
 
 ```bash
-node src/index.js <svgPath> <duration> <fps> <outDir> [options]
+npx tsx src/index.ts <svgPath> <duration> <fps> <outDir> [options]
 ```
 
 ## Arguments

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -6,10 +6,13 @@ import pkg from '../../../package.json';
 export const Header = () => {
   return (
     <header className="header">
-      <h1 className="header-title">
+      <a
+        className="header-title header-title-link"
+        onClick={() => window.location.reload()}
+      >
         <Logo className="header-logo" width="24" height="24" />
         SVG to Video <small className="header-badge">STUDIO</small>
-      </h1>
+      </a>
 
       <nav className="header-nav">
         <a

--- a/web/tests/smoke.spec.ts
+++ b/web/tests/smoke.spec.ts
@@ -4,7 +4,7 @@ test.describe('SVG to Video Web Smoke Test', () => {
   test('should load the page and show the correct title', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/SVG to Video/);
-    await expect(page.locator('h1')).toContainText('SVG to Video');
+    await expect(page.locator('.header-title')).toContainText('SVG to Video');
   });
 
   test('should have a disabled render button by default', async ({ page }) => {


### PR DESCRIPTION
This PR includes two updates:
1. Documentation: Updated CLI usage instructions in README.md and docs/CLI.md to reflect the migration to npx tsx following the TypeScript transition.
2. UI Navigation: Added a home/reset link in the Header component, allowing users to quickly reset the Web Studio application.