### PR TITLE
fix: include missed Header.scss changes

### DIFF
--- a/web/src/components/Header.scss
+++ b/web/src/components/Header.scss
@@ -14,6 +14,16 @@ header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+
+    &.header-title-link {
+      cursor: pointer;
+      text-decoration: none;
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      color: inherit;
+    }
   }
 
   .header-logo {


### PR DESCRIPTION
This PR applies the missing SCSS changes for the new home/reset navigation link added in the previous PR, ensuring correct styling for the Header component.