### PR TITLE
docs: add note about metadata limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Choose the entry point that matches your needs:
 - **Privacy-First**: The Web Studio runs entirely in your browser using **WebCodecs**—your SVG files never leave your computer.
 - **Frame-Accurate**: Our engine scrubs the **Web Animations API**, ensuring every frame is captured exactly as rendered.
 - **Transparent Backgrounds**: Export your animations with a full alpha channel using WebM, perfect for overlays in video editing tools like Premiere or DaVinci Resolve.
-- **Metadata Injection**: Support for custom video titles and comments. Mandatory attribution is automatically appended to the end of the video's comment metadata.
+- **Metadata Injection**: Support for custom video titles and comments. Mandatory attribution is automatically appended to the end of the video's comment metadata. Note: We use the `comment` tag for attribution because FFmpeg/MP4 container support for custom tags like `encoded_by` is inconsistent across platforms.
 - **Versatile**: Whether you need an accessible [Web Studio](#web-studio) for quick conversions or a powerful [CLI tool](#cli--docker-tool) for batch automation and CI/CD pipelines, this project has you covered.
 
 ## 🌐 Web Studio

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,17 +16,17 @@ npx tsx src/index.ts <svgPath> <fps> <outDir> [options]
 
 ## Options
 
-| Option                  | Description                                                                                                                             |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `-d, --duration <secs>` | Desired animation duration in seconds. If omitted, duration is auto-detected.                                                           |
-| `-h, --hold <seconds>`  | Number of seconds to freeze the last frame at the end of the video. (Default: `0`)                                                      |
-| `-f, --force`           | Overwrite the output video if it already exists.                                                                                        |
-| `--resolution <preset>` | Resolution preset: `720p`, `1080p`, or `original`. (Default: `original`)                                                                |
-| `--scale <number>`      | Scale factor for original resolution (1-4). (Default: `1`) - Only used with `--resolution original`.                                    |
-| `--transparent`         | Render with a transparent background. (Cannot be used with `--bg-color`)                                                                |
-| `--bg-color <hex>`      | Background color for the video. (Default: `#ffffff`) - (Cannot be used with `--transparent`)                                            |
-| `--metadata <items...>` | Metadata tags to inject (e.g., `--metadata title=MyVideo`). Note: mandatory attribution is automatically appended to the 'comment' tag. |
-| `--keep-frames`         | Prevents the automatic deletion of temporary `.png` frames after video creation.                                                        |
+| Option                  | Description                                                                                                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-d, --duration <secs>` | Desired animation duration in seconds. If omitted, duration is auto-detected.                                                                                                                                  |
+| `-h, --hold <seconds>`  | Number of seconds to freeze the last frame at the end of the video. (Default: `0`)                                                                                                                             |
+| `-f, --force`           | Overwrite the output video if it already exists.                                                                                                                                                               |
+| `--resolution <preset>` | Resolution preset: `720p`, `1080p`, or `original`. (Default: `original`)                                                                                                                                       |
+| `--scale <number>`      | Scale factor for original resolution (1-4). (Default: `1`) - Only used with `--resolution original`.                                                                                                           |
+| `--transparent`         | Render with a transparent background. (Cannot be used with `--bg-color`)                                                                                                                                       |
+| `--bg-color <hex>`      | Background color for the video. (Default: `#ffffff`) - (Cannot be used with `--transparent`)                                                                                                                   |
+| `--metadata <items...>` | Metadata tags to inject (e.g., `--metadata title=MyVideo`). Note: Mandatory attribution is automatically appended to the 'comment' tag, as FFmpeg/MP4 container support for other custom tags is inconsistent. |
+| `--keep-frames`         | Prevents the automatic deletion of temporary `.png` frames after video creation.                                                                                                                               |
 
 ## Environment Variables
 


### PR DESCRIPTION
This PR adds a note to the README and CLI documentation explaining the metadata attribution strategy due to FFmpeg limitations.