### PR TITLE
fix: Next.js deployment pathing and SEO integrity

### DIFF
--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './dist/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './dist/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,7 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Required for GitHub Pages project site deployment
-  basePath: process.env.NODE_ENV === 'production' ? '/svg-to-video' : '',
+  basePath: '/svg-to-video',
+  assetPrefix: '/svg-to-video/',
   // Ensure output is standalone for static export or serverless deployment
   output: 'export',
   distDir: 'dist', // Match existing Vite output directory

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,8 +1,10 @@
+const isProd = process.env.NODE_ENV === 'production';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Required for GitHub Pages project site deployment
-  basePath: '/svg-to-video',
-  assetPrefix: '/svg-to-video/',
+  basePath: isProd ? '/svg-to-video' : '',
+  assetPrefix: isProd ? '/svg-to-video/' : '',
   // Ensure output is standalone for static export or serverless deployment
   output: 'export',
   distDir: 'dist', // Match existing Vite output directory

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -54,10 +54,7 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <script
-          src={`${process.env.NODE_ENV === 'production' ? '/svg-to-video' : ''}/coi-serviceworker.js`}
-          async
-        />
+        <script src="./coi-serviceworker.js" async />
         {process.env.NODE_ENV === 'production' && (
           <Script
             src="./assets/3rd-party/analytics.js"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
         />
         {process.env.NODE_ENV === 'production' && (
           <Script
-            src="/assets/3rd-party/analytics.js"
+            src="./assets/3rd-party/analytics.js"
             data-website-id="4489aba4-cf29-439e-9491-e36f2a531a63"
             data-domains="gehdoc.github.io"
             data-host-url="https://cloud.umami.is"


### PR DESCRIPTION
This PR finalizes the Next.js migration by fixing deployment pathing issues for GitHub Pages and restoring all SEO metadata parity. Key fixes:
- Added .nojekyll to prevent GitHub Pages from ignoring the _next directory.
- Restored conditional basePath/assetPrefix to ensure clean local development.
- Switched to relative paths for analytics and assets to fix 404s.

Closes #72